### PR TITLE
hide multi-source smk map example

### DIFF
--- a/pages/web-mapping-frameworks/SMK.md
+++ b/pages/web-mapping-frameworks/SMK.md
@@ -23,8 +23,8 @@ Last updated 2021-12-21
   - Assisted Living and Residential Care Locations - [http://moh.apps.gov.bc.ca/alrc/](http://moh.apps.gov.bc.ca/alrc/)
  * [Frequently Asked Questions](https://github.com/bcgov/smk-cli/wiki/Simple-Map-Kit-and-SMK-Editor-FAQs)
  
-Example of an embedded SMK map that sources data from the BCGW Warehouse via MPCM and also from an uploaded CSV data file:
-<iframe src="https://nicoledegreef.github.io/smk-moh-hsat/" height="600px" width="100%" style="border:none;"></iframe>
+<!-- Example of an embedded SMK map that sources data from the BCGW Warehouse via MPCM and also from an uploaded CSV data file:
+<iframe src="https://nicoledegreef.github.io/smk-moh-hsat/" height="600px" width="100%" style="border:none;"></iframe> -->
 
 ## Context
 

--- a/pages/web-mapping-frameworks/SMK.md
+++ b/pages/web-mapping-frameworks/SMK.md
@@ -8,7 +8,7 @@ sidenav: docs
 
 ---
 
-Last updated 2021-12-21
+Last updated 2024-11-08
 
 ## Status
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

While researching bcmaps-options, I found that the GitHub page written by @NicoledeGreef is missing. This PR simply hides this inline frame.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
<!-- New feature (non-breaking change which adds functionality) -->
Documentation (non-breaking change with enhancements to documentation) 
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if appropriate)
- [x] I built and run locally to ensure no styles or formats break (if applicable)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
